### PR TITLE
Upgrade gradle version from 6.1 to 6.8

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This fixes a compatibility issue with Ghidra 10.1, which requires Gradle 6.4 at least. 

The current Gradle is 6.1, which no longer can build the extension since Ghidra 10.1.
```
>gradlew.bat

FAILURE: Build failed with an exception.

* Where:
Script 'C:\Users\tanda\Desktop\RnD\SecurityCamp\ghidra\support\buildExtension.gradle' line: 45

* What went wrong:
A problem occurred evaluating script.
> Requires at least Gradle 6.4, but was run with 6.1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```

This is due to the change described in the release note of Ghidra 10.1.
https://htmlpreview.github.io/?https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_10.1_build/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.html
```
Build. Increased minimum supported Gradle version from 6.0 to 6.4. (GP-1521, Issue #3650)
```

6.8 is the last 6.x version. I have confirmed the compiled extension works as before after this change.