### PR TITLE
Updated gradle version and subsequent file fixes for Ghidra 11.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,12 +44,17 @@ configurations {
 
 dependencies {
     toCopy 'org.json:json:20200518'      
-    implementation configurations.toCopy    
+    implementation files(configurations.toCopy.files)    
 }
 
 task copyToLib(type: Copy) {
     from configurations.toCopy 
     into 'lib'
 }
+
+// Ensure copyToLib runs before compileJava and copyDependencies
+// This was probably a hack, IDK
+tasks.compileJava.dependsOn copyToLib
+tasks.copyDependencies.dependsOn copyToLib
 
 processResources.dependsOn copyToLib

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This should work for Ghidra versions 11.2 and after.

I updated gradle and its wrapper to 8.10, so the build file needed to be altered due to version changes, but unclear if what I did was the intended way of fixing it.

Resolves #15 