### PR TITLE
Fix NTHeader() constructor API - Update EfiUtils.java

### DIFF
--- a/src/main/java/efiSeek/EfiSeekAnalyzer.java
+++ b/src/main/java/efiSeek/EfiSeekAnalyzer.java
@@ -74,7 +74,7 @@ public class EfiSeekAnalyzer extends AbstractAnalyzer {
 				!program.getLanguage().isBigEndian());
 			int ntHeaderOffset = reader.readInt(0x3C);
 			ntHeader = new NTHeader(reader, ntHeaderOffset,
-							PortableExecutable.SectionLayout.FILE, false, false);
+							PortableExecutable.SectionLayout.FILE, false);
 		} catch (Exception e) {
 			return false;
 		}

--- a/src/main/java/efiSeek/EfiUtils.java
+++ b/src/main/java/efiSeek/EfiUtils.java
@@ -113,7 +113,7 @@ public abstract class EfiUtils extends FlatProgramAPI {
 				!getCurrentProgram().getLanguage().isBigEndian());
 		int ntHeaderOffset = reader.readInt(0x3C);
 		ntHeader = new NTHeader(reader, ntHeaderOffset,
-			PortableExecutable.SectionLayout.FILE, false, false);
+			PortableExecutable.SectionLayout.FILE, false);
 
 		long baseEntyPoint = ntHeader.getOptionalHeader().getAddressOfEntryPoint();
 		return getCurrentProgram().getImageBase().add(baseEntyPoint);


### PR DESCRIPTION
In Ghidra 12.0 the API for the NTHeader() constructor changed, leading to errors.

API documentation:
https://ghidra.re/ghidra_docs/api/ghidra/app/util/bin/format/pe/NTHeader.html#%3Cinit%3E(ghidra.app.util.bin.BinaryReader,int,ghidra.app.util.bin.format.pe.PortableExecutable.SectionLayout,boolean)

Fix already merged into ghidra-firmware-utils (was a couple of hours too slow there, Doh):
https://github.com/al3xtjames/ghidra-firmware-utils/pull/37